### PR TITLE
Add Post Cards page template and update ThemeKit design tokens

### DIFF
--- a/includes/modules/PostCards/assets/css/post-cards.css
+++ b/includes/modules/PostCards/assets/css/post-cards.css
@@ -3,14 +3,14 @@
  */
 
 .cmpc-wrapper {
-    --cmpc-accent: #3498DB;
+    --cmpc-accent: var(--cm-color-primary, #3498DB);
     --cmpc-ratio: 4/3;
     --cmpc-radius: var(--cm-radius, 16px);
     --cmpc-gap: var(--cm-gap, 24px);
     --cmpc-transition: var(--cm-transition, all 0.3s cubic-bezier(0.4, 0, 0.2, 1));
     
     position: relative;
-    font-family: var(--cm-font-body, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+    font-family: var(--cm-font-body, 'Roboto', sans-serif);
 }
 
 /* Aspect ratio variants */
@@ -122,7 +122,7 @@
     border-radius: var(--cmpc-radius);
     overflow: hidden;
     transition: var(--cmpc-transition);
-    background: white;
+    background: var(--cm-color-background, #ffffff);
     box-shadow: var(--cm-shadow, 0 4px 20px rgba(0, 0, 0, 0.1));
 }
 
@@ -171,7 +171,7 @@
     gap: 12px;
     margin-bottom: 12px;
     font-size: 14px;
-    color: #666;
+    color: var(--cm-color-text, #666);
 }
 
 .cmpc-card__category {
@@ -190,13 +190,15 @@
     font-size: 18px;
     font-weight: 700;
     line-height: 1.3;
-    color: #2c3e50;
+    color: var(--cm-color-text, #2c3e50);
+    font-family: var(--cm-font-heading, 'Poppins', sans-serif);
 }
 
 .cmpc-card__excerpt {
     font-size: 14px;
     line-height: 1.5;
-    color: #7f8c8d;
+    color: var(--cm-color-text, #7f8c8d);
+    font-family: var(--cm-font-body, 'Roboto', sans-serif);
 }
 
 /* Hover Effects */

--- a/includes/modules/ThemeKit/assets/css/theme.css
+++ b/includes/modules/ThemeKit/assets/css/theme.css
@@ -24,19 +24,25 @@
     --cm-transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     --cm-transition-fast: all 0.15s ease-out;
     --cm-transition-slow: all 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-    
+
     /* Shadows */
     --cm-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
     --cm-shadow-hover: 0 8px 40px rgba(0, 0, 0, 0.15);
     --cm-shadow-focus: 0 0 0 3px rgba(59, 130, 246, 0.1);
-    
+
+    /* Colors */
+    --cm-color-primary: #1e40af;
+    --cm-color-secondary: #f97316;
+    --cm-color-background: #ffffff;
+    --cm-color-text: #111827;
+
     /* Gradients */
     --cm-gradient-overlay: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.8) 100%);
     --cm-gradient-subtle: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 100%);
-    
+
     /* Typography */
-    --cm-font-heading: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    --cm-font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --cm-font-heading: 'Poppins', sans-serif;
+    --cm-font-body: 'Roboto', sans-serif;
     --cm-font-mono: 'SF Mono', Consolas, 'Liberation Mono', monospace;
     
     /* Z-index layers */

--- a/includes/modules/ThemeKit/module.php
+++ b/includes/modules/ThemeKit/module.php
@@ -53,6 +53,12 @@ class ThemeKit {
             --cm-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
             --cm-shadow-hover: 0 8px 40px rgba(0, 0, 0, 0.15);
             --cm-gradient-overlay: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.8) 100%);
+            --cm-color-primary: #1e40af;
+            --cm-color-secondary: #f97316;
+            --cm-color-background: #ffffff;
+            --cm-color-text: #111827;
+            --cm-font-heading: 'Poppins', sans-serif;
+            --cm-font-body: 'Roboto', sans-serif;
         }
         </style>
         <?php
@@ -67,7 +73,13 @@ class ThemeKit {
             'radius' => '16px',
             'transition' => 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
             'shadow' => '0 4px 20px rgba(0, 0, 0, 0.1)',
-            'shadow-hover' => '0 8px 40px rgba(0, 0, 0, 0.15)'
+            'shadow-hover' => '0 8px 40px rgba(0, 0, 0, 0.15)',
+            'color-primary' => '#1e40af',
+            'color-secondary' => '#f97316',
+            'color-background' => '#ffffff',
+            'color-text' => '#111827',
+            'font-heading' => "'Poppins', sans-serif",
+            'font-body' => "'Roboto', sans-serif"
         ];
         
         return isset($tokens[$token]) ? $tokens[$token] : $default;

--- a/templates/cm-post-cards-template.json
+++ b/templates/cm-post-cards-template.json
@@ -1,0 +1,31 @@
+{
+  "title": "CM Post Cards Page",
+  "type": "page",
+  "content": [
+    {
+      "id": "section1",
+      "elType": "section",
+      "settings": {},
+      "elements": [
+        {
+          "id": "column1",
+          "elType": "column",
+          "settings": {},
+          "elements": [
+            {
+              "id": "widget1",
+              "elType": "widget",
+              "widgetType": "cm-suite-post-cards",
+              "settings": {
+                "posts_per_page": 6,
+                "layout_type": "",
+                "columns": "3",
+                "show_category": "yes"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Elementor page template featuring the CM Post Cards widget
- Extend ThemeKit design tokens with color palette and typography variables
- Align Post Cards styles with new ThemeKit tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa79b76c448326b0fef558e04bf838