### PR TITLE
feat: add article modal to stories player

### DIFF
--- a/includes/modules/StoriesPlayer/assets/css/stories-player.css
+++ b/includes/modules/StoriesPlayer/assets/css/stories-player.css
@@ -201,6 +201,52 @@
     border-color: rgba(255, 0, 0, 0.5);
 }
 
+/* Article modal */
+.cmsp-article-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 1000000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+}
+
+.cmsp-article-modal[aria-hidden="false"] {
+    display: flex;
+}
+
+.cmsp-article-modal .cmsp-modal-dialog {
+    background: #fff;
+    color: #000;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 20px;
+    border-radius: 8px;
+    position: relative;
+}
+
+.cmsp-article-modal .cmsp-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: transparent;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #000;
+}
+
+.cmsp-article-modal .cmsp-modal-close:focus {
+    outline: 2px solid #000;
+    outline-offset: 2px;
+}
+
+.cmsp-article-modal .cmsp-modal-title {
+    margin-top: 0;
+}
+
 /* Stories Container */
 .cmsp-stories {
     width: 100%;

--- a/includes/modules/StoriesPlayer/assets/js/stories-player.js
+++ b/includes/modules/StoriesPlayer/assets/js/stories-player.js
@@ -38,6 +38,9 @@
             this.storyAvatar = this.container.querySelector('.cmsp-story-avatar');
             this.loading = this.container.querySelector('.cmsp-loading');
             this.error = this.container.querySelector('.cmsp-error');
+            this.articleModal = document.getElementById(containerId + '-article-modal');
+            this.articleTitle = this.articleModal?.querySelector('.cmsp-modal-title');
+            this.articleContent = this.articleModal?.querySelector('.cmsp-modal-content');
             
             this.init();
         }
@@ -74,6 +77,24 @@
             if (playPauseBtn) {
                 playPauseBtn.addEventListener('click', () => this.togglePlayPause());
             }
+
+            // Open article button
+            const openArticleBtn = this.container.querySelector('.cmsp-open-article');
+            if (openArticleBtn) {
+                openArticleBtn.addEventListener('click', () => this.openArticle());
+            }
+
+            if (this.articleModal) {
+                const modalClose = this.articleModal.querySelector('.cmsp-modal-close');
+                if (modalClose) {
+                    modalClose.addEventListener('click', () => this.closeArticle());
+                }
+                this.articleModal.addEventListener('click', (e) => {
+                    if (e.target === this.articleModal) {
+                        this.closeArticle();
+                    }
+                });
+            }
             
             // Navigation buttons
             const prevBtn = this.container.querySelector('.cmsp-nav-prev');
@@ -100,7 +121,11 @@
                 switch (e.key) {
                     case 'Escape':
                         e.preventDefault();
-                        this.close();
+                        if (this.articleModal && this.articleModal.getAttribute('aria-hidden') === 'false') {
+                            this.closeArticle();
+                        } else {
+                            this.close();
+                        }
                         break;
                     case 'ArrowLeft':
                         e.preventDefault();
@@ -423,7 +448,7 @@
          */
         close() {
             if (!this.isOpen) return;
-            
+
             this.isOpen = false;
             this.stopAutoPlay();
             
@@ -441,6 +466,41 @@
             if (this.settings.deepLink) {
                 this.clearURL();
             }
+        }
+
+        /**
+         * Open article modal
+         */
+        async openArticle() {
+            if (!this.articleModal) return;
+            const story = this.stories[this.currentStoryIndex];
+            if (!story) return;
+
+            try {
+                const wpRest = cmStoriesAjax.restUrl.replace('cm/v1/', 'wp/v2/');
+                const response = await fetch(`${wpRest}cm_story/${story.id}`);
+                if (!response.ok) throw new Error('Failed to load article');
+                const data = await response.json();
+                if (this.articleTitle) {
+                    this.articleTitle.textContent = data.title?.rendered || story.title || '';
+                }
+                if (this.articleContent) {
+                    this.articleContent.innerHTML = data.content?.rendered || '';
+                }
+                this.articleModal.style.display = 'flex';
+                this.articleModal.setAttribute('aria-hidden', 'false');
+            } catch (err) {
+                console.error('Stories Player: Error loading article', err);
+            }
+        }
+
+        /**
+         * Close article modal
+         */
+        closeArticle() {
+            if (!this.articleModal) return;
+            this.articleModal.style.display = 'none';
+            this.articleModal.setAttribute('aria-hidden', 'true');
         }
         
         /**

--- a/includes/modules/StoriesPlayer/widgets/class-cm-stories-player.php
+++ b/includes/modules/StoriesPlayer/widgets/class-cm-stories-player.php
@@ -184,6 +184,7 @@ class CM_Stories_Player extends Widget_Base {
                                 <span class="cmsp-play-icon">▶</span>
                                 <span class="cmsp-pause-icon">⏸</span>
                             </button>
+                            <button class="cmsp-control-btn cmsp-open-article" aria-label="<?php esc_attr_e('Read article', 'cm-suite-elementor'); ?>">ℹ</button>
                         </div>
                     <?php endif; ?>
                     
@@ -215,9 +216,16 @@ class CM_Stories_Player extends Widget_Base {
                 </div>
                 
             </div>
-            
+
         </div>
-        
+        <div id="<?php echo esc_attr($widget_id); ?>-article-modal" class="cmsp-article-modal" style="display: none;" aria-hidden="true">
+            <div class="cmsp-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($widget_id); ?>-article-title">
+                <button class="cmsp-modal-close" aria-label="<?php esc_attr_e('Close article', 'cm-suite-elementor'); ?>">×</button>
+                <h2 id="<?php echo esc_attr($widget_id); ?>-article-title" class="cmsp-modal-title"></h2>
+                <div class="cmsp-modal-content"></div>
+            </div>
+        </div>
+
         <script>
         document.addEventListener('DOMContentLoaded', function() {
             if (window.CMSuiteStoriesPlayer) {


### PR DESCRIPTION
## Summary
- add open-article button and hidden modal in CM Stories Player widget
- load article content via REST and manage modal display in player script
- style modal and close controls with accessible defaults

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 3 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68aa7a02077883269622188d5ecafb9f